### PR TITLE
Add GitHub Action workflow to run flutter unit tests

### DIFF
--- a/.github/workflows/flutter_unit_tests.yaml
+++ b/.github/workflows/flutter_unit_tests.yaml
@@ -1,0 +1,18 @@
+name: Flutter Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: subosito/flutter-action@v2
+      with:
+        channel: 'stable'
+    - run: flutter pub get
+    - run: flutter test


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to run Flutter unit tests on every pull request. Closes #16.