### PR TITLE
feat: Move log and flag management buttons to settings page (Issue #30)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -746,22 +746,6 @@ class _SecretAgentHomeState extends State<SecretAgentHome> {
                     },
                   ),
                   IconButton(
-                    icon: const Icon(Icons.bug_report_outlined),
-                    onPressed: _debugAction,
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.flag), // New flag icon
-                    onPressed: () {
-                      DebugFeatures.show(
-                        context,
-                        availableFeatures: [
-                          Feature('DECREMENT', name: 'Decrement'),
-                          Feature('RESET', name: 'Reset'),
-                        ],
-                      );
-                    },
-                  ),
-                  IconButton(
                     icon: const Icon(Icons.settings),
                     onPressed: () {
                       Navigator.of(context).push(

--- a/lib/settings_page.dart
+++ b/lib/settings_page.dart
@@ -2,6 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:secret_agent/database_helper.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:restart_app/restart_app.dart';
+import 'package:talker_flutter/talker_flutter.dart';
+import 'package:feature_flags/feature_flags.dart';
+import 'package:secret_agent/main.dart';
 
 class SettingsPage extends StatelessWidget {
   final int? agentId;
@@ -16,6 +19,46 @@ class SettingsPage extends StatelessWidget {
         padding: const EdgeInsets.all(16.0),
         child: Column(
           children: [
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                icon: const Icon(Icons.bug_report_outlined),
+                label: const Text('View Logs'),
+                onPressed: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (context) => TalkerScreen(
+                        talker: talker,
+                        theme: TalkerScreenTheme(
+                          cardColor: Theme.of(context).cardColor,
+                          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+                          textColor:
+                              Theme.of(context).textTheme.bodyLarge?.color ?? Colors.white,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                icon: const Icon(Icons.flag),
+                label: const Text('Manage Feature Flags'),
+                onPressed: () {
+                  DebugFeatures.show(
+                    context,
+                    availableFeatures: [
+                      Feature('DECREMENT', name: 'Decrement'),
+                      Feature('RESET', name: 'Reset'),
+                    ],
+                  );
+                },
+              ),
+            ),
+            const SizedBox(height: 16),
             SizedBox(
               width: double.infinity,
               child: ElevatedButton(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.0+30
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
This PR moves the log inspection button and flag management button from the main agent page to the settings page, addressing Issue #30.