### PR TITLE
Feat: Use download directory for feedback screenshots

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -250,7 +250,7 @@ class _SecretAgentHomeState extends State<SecretAgentHome> {
         // Show feedback UI
         BetterFeedback.of(context).show(
           (feedback) async {
-            // Save the screenshot to a temporary file
+            // Save the screenshot to the downloads directory
             final directory = await getDownloadsDirectory();
             final file = File('${directory!.path}/feedback_screenshot.png');
             await file.writeAsBytes(feedback.screenshot);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -251,8 +251,8 @@ class _SecretAgentHomeState extends State<SecretAgentHome> {
         BetterFeedback.of(context).show(
           (feedback) async {
             // Save the screenshot to a temporary file
-            final directory = await getTemporaryDirectory();
-            final file = File('${directory.path}/feedback_screenshot.png');
+            final directory = await getDownloadsDirectory();
+            final file = File('${directory!.path}/feedback_screenshot.png');
             await file.writeAsBytes(feedback.screenshot);
 
             talker.info('Feedback saved to: ${file.path}');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -251,8 +251,8 @@ class _SecretAgentHomeState extends State<SecretAgentHome> {
         BetterFeedback.of(context).show(
           (feedback) async {
             // Save the screenshot to the downloads directory
-            final directory = await getDownloadsDirectory();
-            final file = File('${directory!.path}/feedback_screenshot.png');
+            final directory = await getDownloadsDirectory() ?? await getTemporaryDirectory();
+            final file = File('${directory.path}/feedback_screenshot.png');
             await file.writeAsBytes(feedback.screenshot);
 
             talker.info('Feedback saved to: ${file.path}');


### PR DESCRIPTION
This PR addresses issue #61 by changing the feedback screenshot saving location from the temporary directory to the downloads directory.