### PR TITLE
feat: Implement manual GitHub feedback submission

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,7 +51,8 @@ dependencies:
   feature_flags: ^0.1.4
   multi_select_flutter: ^4.1.3 # Added this line
   shake: ^2.2.0 # Add shake package
-  feedback: ^3.0.0 # Add feedback package
+  http: ^1.2.1
+  url_launcher: ^6.2.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR implements the GitHub feedback submission functionality manually, replacing the problematic github_oauth and feedback packages. Users can now submit feedback via a dialog, which will attempt to create a GitHub issue using the GitHub API. Screenshot attachment is noted as a local file path for now.