### PR TITLE
feat: Set prompt text field to single line

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1006,8 +1006,8 @@ class _SecretAgentHomeState extends State<SecretAgentHome> {
                   children: [
                     TextField(
                       controller: _textController,
-                      minLines: 2,
-                      maxLines: 2,
+                      minLines: 1,
+                      maxLines: 1,
                       textInputAction: TextInputAction.send, // Add this line
                       decoration: InputDecoration(
                         hintText: 'Ask Secret Agent',


### PR DESCRIPTION
Closes #77\n\nThis PR sets the prompt text field to a single line as requested in issue #77, improving screen space utilization.